### PR TITLE
readthedocs failing to build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@
 # Required
 version: 2
 
+python:
+  install:
+    - requirements: docs/requirements.txt
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-rtd-theme==1.2.2


### PR DESCRIPTION
Running Sphinx v5.3.0
making output directory... done
WARNING: sphinx_rtd_theme (< 0.3.0) found. It will not be available since Sphinx-6.0