### PR TITLE
readthedocs failings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,8 +11,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-import os
-import sys
+import logging
+import os.path
+import re
+import subprocess
 
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../..'))
@@ -49,7 +51,7 @@ todo_include_todos = False
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.autosectionlabel','sphinx_rtd_theme'
+    'sphinx.ext.autodoc', 'sphinx.ext.viewcode', 'sphinx.ext.autosectionlabel'
 ]
 
 autosectionlabel_prefix_document = True
@@ -63,12 +65,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output -------------------------------------------------
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['rtd_theme', ]
+templates_path = ['_templates']
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-#
-html_theme = 'sphinx_rtd_theme'
+# Maps git branches to Sphinx themes
+default_html_theme = 'sphinx_rtd_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
-sphinx-rtd-theme==1.2.2
+Sphinx==1.7.0
+
+# Theme
+sphinx-rtd-theme==0.2.4


### PR DESCRIPTION
raise ThemeError(__('no theme named %r found (missing theme.conf?)') % name) sphinx.errors.ThemeError: no theme named 'sphinx_rtd_theme' found (missing theme.conf?)